### PR TITLE
release 2.x with breaking changes around ruby versions:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
+- 2.3.0
+- 2.4.0
 notifications:
   email:
     recipients:
@@ -26,8 +27,9 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
+    rvm: 2.3.0
+    rvm: 2.4.1
     repo: sensu-plugins/sensu-plugins-couchdb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,21 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-###[Unreleased]
+### [Unreleased]
 
-## 1.0.0 - 2017-07-8
+# [2.0.0] - 2017-07-08
+### Breaking Changes
+- removed ruby 1.9 support (@majormoses)
+
+### Added
+- ruby 2.3 and 2.4 testing (@majormoses)
+
+### Changed
+- misc repo changes to align with newer plugins based on our new skel (@majormoses)
+
+## [1.0.0] - 2017-07-8
 ### No-op
 - no code change bumping to 1.0 to prep for breaking changes in 2.x. Leave no user without a reasonable upgrade path (@majormoses)
 
@@ -13,11 +23,11 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - misc fixes in changelog and pr templates (@majormoses)
 - ensured all checks are exectuable (@majormoses)
 
-## 0.0.2 - 2016-11-01
+## [0.0.2] - 2016-11-01
 ### Added
 - check-couchdb-alive.rb
 
-## 0.0.1 - 2016-02-04
+## [0.0.1] - 2016-02-04
 ### Changed
 - adjusted dependencies
 - clean repo
@@ -27,7 +37,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - update certs
 - metrics-couchdb.rb
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-couchdb/compare/1.0.0...HEAD
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-couchdb/compare/2.0.0...HEAD
+[2.0.0]: https://github.com/sensu-plugins/sensu-plugins-couchdb/compare/1.0.0...2.0.0
 [1.0.0]: https://github.com/sensu-plugins/sensu-plugins-couchdb/compare/0.0.2...1.0.0
 [0.0.2]: https://github.com/sensu-plugins/sensu-plugins-couchdb/compare/v0.0.1...0.0.2
 [0.0.1]: https://github.com/sensu-plugins/sensu-plugins-couchdb/compare/7b922f558627beab911eb1113a184ac66a2a212b...v0.0.1

--- a/Rakefile
+++ b/Rakefile
@@ -6,19 +6,10 @@ require 'rubocop/rake_task'
 require 'yard'
 require 'yard/rake/yardoc_task'
 
-desc 'Don\'t run Rubocop for unsupported versions'
-begin
-  args = if RUBY_VERSION >= '2.0.0'
-           [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
-         else
-           [:spec, :make_bin_executable, :yard]
-         end
-end
-
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -34,14 +25,16 @@ end
 
 desc 'Test for binstubs'
 task :check_binstubs do
-  bin_list = Gem::Specification.load('sensu-plugins-couchdb.gemspec').executables
-  bin_list.each do |b|
-    `which #{ b }`
-    unless $CHILD_STATUS.success?
-      puts "#{b} was not a binstub"
-      exit
+  unless Dir.glob('bin/**/*.rb').empty?
+    bin_list = Gem::Specification.load('sensu-plugins-couchdb.gemspec').executables
+    bin_list.each do |b|
+      `which #{ b }`
+      unless $CHILD_STATUS.success?
+        puts "#{b} was not a binstub"
+        exit
+      end
     end
   end
 end
 
-task default: args
+task default: %i[spec make_bin_executable yard rubocop check_binstubs]

--- a/lib/sensu-plugins-couchdb/version.rb
+++ b/lib/sensu-plugins-couchdb/version.rb
@@ -1,6 +1,6 @@
 module SensuPluginsCouchdb
   module Version
-    MAJOR = 1
+    MAJOR = 2
     MINOR = 0
     PATCH = 0
 

--- a/sensu-plugins-couchdb.gemspec
+++ b/sensu-plugins-couchdb.gemspec
@@ -2,23 +2,15 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
+require_relative 'lib/sensu-plugins-couchdb'
 
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-couchdb'
-else
-  require_relative 'lib/sensu-plugins-couchdb'
-end
-
-# pvt_key = 'certs/gem-private_key.pem'
-
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu-Plugins and contributors']
-  # s.cert_chain             = ['certs/sensu-plugins.pem']
   s.date                   = Date.today.to_s
   s.description            = 'Sensu couchdb plugins'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-couchdb'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => 'sensu-plugin',
@@ -30,8 +22,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
-  #  s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME.end_with?('gem')
+  s.required_ruby_version  = '>= 2.0.0'
   s.summary                = 'Sensu plugins for couchdb'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsCouchdb::Version::VER_STRING
@@ -44,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
+  s.add_development_dependency 'rubocop',                   '~> 0.49.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
- removed ruby 1.9 support
- added travis testing for ruby 2.3 and 2.4
- misc repo cleanup

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

part of: https://github.com/sensu-plugins/sensu-plugins-feature-requests/issues/27

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass


#### Purpose
remove ruby 1.9 support, add testing for ruby 2.4
#### Known Compatibility Issues
ruby installs < 2.0 will fail miserably which is why I did a major release prior to this to ensure that we do not break anyone who is pinning responsibly.